### PR TITLE
Fixed several bugs

### DIFF
--- a/addon/globalPlugins/sharedComputer.py
+++ b/addon/globalPlugins/sharedComputer.py
@@ -205,7 +205,6 @@ class AddonSettingsDialog(SettingsDialog):
 		self.activateList.SetFocus()
 
 	def onOk(self,evt):
-		super(AddonSettingsDialog, self).onOk(evt)
 		config.conf["sharedComputer"]["numLockActivationChoice"] = self.activateList.Selection
 		# write only to the normal configuration
 		newSettings = {"sharedComputer": {
@@ -213,6 +212,7 @@ class AddonSettingsDialog(SettingsDialog):
 			"volumeLevel": self.volumeLevel.Value}}
 		config.conf._profileCache[None].update(newSettings)
 		config.conf.profiles[0].update(newSettings)
+		super(AddonSettingsDialog, self).onOk(evt)
 
 # Audio Stuff
 def getVolumeObject():

--- a/addon/globalPlugins/sharedComputer.py
+++ b/addon/globalPlugins/sharedComputer.py
@@ -31,7 +31,10 @@ config.conf.spec["sharedComputer"] = confspec
 speakers = None
 
 def _getBaseValue(key):
-	val1 = config.conf.profiles[0]["sharedComputer"].get(key)
+	try:
+		val1 = config.conf.profiles[0]["sharedComputer"].get(key)
+	except:
+		val1 = None
 	val2 = config.conf["sharedComputer"].get(key)
 	return int(val1) if val1 is not None else int(val2)
 

--- a/addon/globalPlugins/sharedComputer.py
+++ b/addon/globalPlugins/sharedComputer.py
@@ -112,10 +112,10 @@ class AddonSettingsDialog(SettingsDialog):
 # Translators: Title of a dialog.
 	title = _("Shared Computer Settings (F1 for Context Help)")
 	# Translators: title of the browsable help message
-	helpTitle = _(u"Help")
+	helpTitle = _("Help")
 	# Translators: advice on how to close the browsable help message
-	hint = _(u"Press escape to close this message.")
-	hint = u"<p>{}</p>".format(hint)
+	hint = _("Press escape to close this message.")
+	hint = "<p>{}</p>".format(hint)
 	lastFocus = None
 	helpDict = {}
 	with open(helpPath,'r') as helpFile:

--- a/addon/globalPlugins/sharedComputer.py
+++ b/addon/globalPlugins/sharedComputer.py
@@ -160,11 +160,11 @@ class AddonSettingsDialog(SettingsDialog):
 		self.volumeList.Bind(wx.EVT_CHOICE, self.onChoice) 
 		self.volumeLevel.Bind(wx.EVT_CHAR_HOOK, self.onKey)
 		for number, child in enumerate([self.activateList, self.volumeList, self.volumeLevel], 1):
-			self.helpDict[child.GetId()] = u'\n'.join((self.sections[0], self.sections[number], self.hint, self.sections[4]))
+			self.helpDict[child.GetId()] = '\n'.join((self.sections[0], self.sections[number], self.hint, self.sections[4]))
 			child.Bind(wx.EVT_HELP, self.onHelp)
 
 	def onDialogActivate(self, evt):
-		"Ensures that the current control will be the same after switching to another window and back"
+		""" Ensures that the current control will be the same after switching to another window and back """
 		# store focus when the user switches to another window
 		if not evt.GetActive():
 			self.lastFocus = self.FindFocus()

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -26,3 +26,4 @@ def onInstall():
 		except KeyError:
 			pass
 	conf.spec["sharedComputer"] = confspec
+	conf.save()

--- a/sconstruct
+++ b/sconstruct
@@ -23,7 +23,7 @@ def md2html(source, dest):
 		mdText = f.read()
 		for k, v in headerDic.iteritems():
 			mdText = mdText.replace(k, v, 1)
-		htmlText = markdown.markdown(mdText, ['markdown.extensions.extra'])
+		htmlText = markdown.markdown(mdText, extensions=['markdown.extensions.extra'])
 	with codecs.open(dest, "w", "utf-8") as f:
 		f.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 			"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n" +


### PR DESCRIPTION
In this pull request, the following bugs have been fixed:

* InstallTasks: call conf.save() after updating the config spec. If the user has the option save on exit disabled, this task did nothing.
* Removed unnecesary 'u' flag on many strings (Python 3 compatibility).
* Function _getBaseValue: if an exception is raised when trying to get val1, set val1 to None
* Function onOk: call super() in last place. If it is called in the first line, controls are destroyed and you can't retrieve information.
* sconstruct: use the extensions keyword when calling markdown.markdown, fixing build errors.

Let's make this add-on come to life again!